### PR TITLE
Range Mode: one smack, many tracks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,14 @@ hs_err_pid*.log
 replay_pid*.log
 *.jks
 .claude/settings.local.json
+
+# Local dev scratch — verification screenshots, demo videos, and step folders (not source).
+# Root-anchored so real drawables/assets under app/src are unaffected.
+/screenshot_*.png
+/*.mp4
+/analytics_cleanup/
+/release_test/
+/splash_screen/
+/ui_updates/
+/visual_verify/
+/walking_strip/

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.smacktrack.golf"
         minSdk = 33
         targetSdk = 36
-        versionCode = 10001  // MAJOR * 10000 + MINOR * 100 + PATCH
-        versionName = "1.0.1"
+        versionCode = 10006  // MAJOR * 10000 + MINOR * 100 + PATCH
+        versionName = "1.0.6"
     }
 
     signingConfigs {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,11 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
+    <!-- Remove ad-related permissions injected by Firebase/GMS dependencies — we don't use ads -->
+    <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove" />
+    <uses-permission android:name="android.permission.ACCESS_ADSERVICES_ATTRIBUTION" tools:node="remove" />
+    <uses-permission android:name="android.permission.ACCESS_ADSERVICES_AD_ID" tools:node="remove" />
+
     <application
         android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -45,6 +50,16 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/file_paths" />
         </provider>
+
+        <!-- Remove ad services config injected by Firebase measurement SDK -->
+        <property
+            android:name="android.adservices.AD_SERVICES_CONFIG"
+            android:resource="@xml/file_paths"
+            tools:node="remove" />
+        <uses-library
+            android:name="android.ext.adservices"
+            android:required="false"
+            tools:node="remove" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/smacktrack/golf/MainActivity.kt
+++ b/app/src/main/java/com/smacktrack/golf/MainActivity.kt
@@ -51,6 +51,7 @@ import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.Place
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.FavoriteBorder
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.AlertDialog
@@ -75,6 +76,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -106,6 +108,7 @@ import com.smacktrack.golf.data.AuthManager
 import com.smacktrack.golf.domain.AchievementCategory
 import com.smacktrack.golf.ui.AppSettings
 import com.smacktrack.golf.ui.ShotResult
+import com.smacktrack.golf.ui.RangePhase
 import com.smacktrack.golf.ui.ShotPhase
 import com.smacktrack.golf.ui.ShotTrackerViewModel
 import com.smacktrack.golf.ui.SyncStatus
@@ -119,6 +122,7 @@ import com.smacktrack.golf.ui.screen.AnimatedCounter
 import com.smacktrack.golf.ui.screen.ClubBadge
 import com.smacktrack.golf.ui.screen.DistanceResult
 import com.smacktrack.golf.ui.screen.HistoryScreen
+import com.smacktrack.golf.ui.screen.RangeScreen
 import com.smacktrack.golf.ui.screen.SettingsScreen
 import com.smacktrack.golf.ui.screen.ShareShotButton
 import com.smacktrack.golf.ui.screen.ShotTrackerScreen
@@ -185,6 +189,7 @@ private val allPermissions = arrayOf(
 
 private val navItems = listOf(
     NavItem("Tracker", Icons.Default.Place),
+    NavItem("Range", Icons.Default.Refresh),
     NavItem("Stats", Icons.Default.Star),
     NavItem("History", Icons.AutoMirrored.Default.List)
 )
@@ -194,7 +199,8 @@ private val navItems = listOf(
 fun SmackTrackApp(viewModel: ShotTrackerViewModel) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val context = LocalContext.current
-    var selectedTab by remember { mutableIntStateOf(0) }
+    // Saveable so the visible tab survives config changes in step with the ViewModel's flow state
+    var selectedTab by rememberSaveable { mutableIntStateOf(0) }
     var showSettings by remember { mutableStateOf(false) }
     var splashFinished by remember { mutableStateOf(false) }
     var detailShot by remember { mutableStateOf<ShotResult?>(null) }
@@ -204,11 +210,37 @@ fun SmackTrackApp(viewModel: ShotTrackerViewModel) {
     LaunchedEffect(selectedTab) {
         val screenName = when (selectedTab) {
             0 -> "tracker"
-            1 -> "stats"
-            2 -> "history"
+            1 -> "range"
+            2 -> "stats"
+            3 -> "history"
             else -> "unknown"
         }
         viewModel.analyticsTracker.logScreenView(screenName)
+    }
+
+    // Which tab (if any) owns the screen because a GPS flow is mid-session.
+    // Single-shot: index 0; Range: index 1; -1 = neither (nav free).
+    val shotActive = uiState.phase != ShotPhase.CLUB_SELECT && uiState.phase != ShotPhase.RESULT
+    val rangeActive = uiState.rangePhase == RangePhase.CALIBRATING_ORIGIN ||
+        uiState.rangePhase == RangePhase.TRACKING
+    val activeTab = when {
+        shotActive -> 0
+        rangeActive -> 1
+        else -> -1
+    }
+
+    // Keep the visible tab pinned to an active GPS flow (e.g. after a rotation that reset selectedTab),
+    // so the active session's screen is shown rather than a different tab's content.
+    LaunchedEffect(activeTab) {
+        if (activeTab != -1 && selectedTab != activeTab) selectedTab = activeTab
+    }
+
+    // A finished range session (SUMMARY) is transient — discard it when the user leaves the Range tab
+    // so returning later shows a fresh idle screen, not a stale "Done" summary.
+    LaunchedEffect(selectedTab) {
+        if (selectedTab != 1 && uiState.rangePhase == RangePhase.SUMMARY) {
+            viewModel.rangeReset()
+        }
     }
 
     // Back button closes settings/achievements overlays instead of exiting app
@@ -423,12 +455,12 @@ fun SmackTrackApp(viewModel: ShotTrackerViewModel) {
                     containerColor = MaterialTheme.colorScheme.surface,
                     tonalElevation = 0.dp
                 ) {
-                    val shotActive = uiState.phase != ShotPhase.CLUB_SELECT && uiState.phase != ShotPhase.RESULT
+                    // While a GPS flow is mid-session, lock the bottom nav to that flow's tab (activeTab)
                     navItems.forEachIndexed { index, item ->
                         NavigationBarItem(
                             selected = selectedTab == index,
                             onClick = { selectedTab = index },
-                            enabled = index == 0 || !shotActive,
+                            enabled = activeTab == -1 || index == activeTab,
                             icon = { Icon(item.icon, contentDescription = item.label) },
                             label = {
                                 Text(
@@ -518,7 +550,16 @@ fun SmackTrackApp(viewModel: ShotTrackerViewModel) {
                         newlyUnlockedAchievements = uiState.newlyUnlockedAchievements,
                         onAchievementsSeen = viewModel::clearNewAchievements
                     )
-                    1 -> AnalyticsScreen(
+                    1 -> RangeScreen(
+                        uiState = uiState,
+                        onSelectClub = viewModel::rangeSelectClub,
+                        onStartSession = viewModel::rangeStartSession,
+                        onTrackBall = viewModel::rangeTrackBall,
+                        onEndSession = viewModel::rangeEndSession,
+                        onReset = viewModel::rangeReset,
+                        onDone = viewModel::rangeReset
+                    )
+                    2 -> AnalyticsScreen(
                         shotHistory = uiState.shotHistory,
                         settings = uiState.settings,
                         onDeleteShot = viewModel::deleteShot,

--- a/app/src/main/java/com/smacktrack/golf/ui/ShotTrackerViewModel.kt
+++ b/app/src/main/java/com/smacktrack/golf/ui/ShotTrackerViewModel.kt
@@ -59,6 +59,20 @@ enum class ShotPhase {
     RESULT
 }
 
+/**
+ * Phases of the Range Mode workflow ("one smack, many tracks").
+ *
+ * One origin is calibrated ([CALIBRATING_ORIGIN]), then any number of balls are
+ * measured from it ([TRACKING]) before the session [SUMMARY]. Each tracked ball is
+ * saved as a normal [ShotResult] so it flows into the existing Stats/History.
+ */
+enum class RangePhase {
+    IDLE,
+    CALIBRATING_ORIGIN,
+    TRACKING,
+    SUMMARY
+}
+
 enum class SyncStatus { IDLE, SYNCING, SYNCED, ERROR }
 
 enum class DistanceUnit(val label: String) {
@@ -124,7 +138,15 @@ data class ShotTrackerUiState(
     val gpsAccuracyMeters: Double? = null,
     val calibrationAccuracyMeters: Double? = null,
     val calibrationProgress: Float = 0f,
-    val accountDeleted: Boolean = false
+    val accountDeleted: Boolean = false,
+    // ── Range Mode ("one smack, many tracks") ──
+    val rangePhase: RangePhase = RangePhase.IDLE,
+    val rangeClub: Club = Club.DRIVER,
+    val rangeOrigin: GpsCoordinate? = null,
+    val rangeLiveDistanceYards: Int = 0,
+    val rangeLiveDistanceMeters: Int = 0,
+    val rangeBalls: List<ShotResult> = emptyList(),
+    val rangeCapturing: Boolean = false
 )
 
 class ShotTrackerViewModel(application: Application) : AndroidViewModel(application) {
@@ -154,6 +176,12 @@ class ShotTrackerViewModel(application: Application) : AndroidViewModel(applicat
     private var authObserverJob: Job? = null
     private var errorObserverJob: Job? = null
     private var startAccuracyMeters: Double? = null
+
+    // Range Mode session state (not part of UiState — internal bookkeeping)
+    private var rangeWeather: WeatherData? = null
+    private var rangeTimeoutJob: Job? = null
+    // Bumped each session so a slow weather fetch from a prior session can't clobber a new one
+    private var rangeSessionToken = 0
 
     init {
         achievementRepository.migrateOldKeys()
@@ -473,6 +501,12 @@ class ShotTrackerViewModel(application: Application) : AndroidViewModel(applicat
 
     fun markStart() {
         if (_uiState.value.phase != ShotPhase.CLUB_SELECT) return
+        // Don't start a single shot while a Range session is using GPS (the two flows share the
+        // location stream + foreground service). The nav lock normally prevents reaching here.
+        if (_uiState.value.rangePhase == RangePhase.CALIBRATING_ORIGIN ||
+            _uiState.value.rangePhase == RangePhase.TRACKING) return
+        // Discard any lingering finished-range summary so it can't be torn down mid-shot later
+        if (_uiState.value.rangePhase == RangePhase.SUMMARY) rangeReset()
         // Default to Driver if no club selected yet
         if (_uiState.value.selectedClub == null) {
             _uiState.update { it.copy(selectedClub = Club.DRIVER) }
@@ -585,20 +619,8 @@ class ShotTrackerViewModel(application: Application) : AndroidViewModel(applicat
                     startCoord
                 }
 
-            var distanceMeters = haversineMeters(startCoord, endCoord)
-            var distanceYards = metersToYards(distanceMeters)
-
-            // Clamp implausible distances (NaN, infinite, or >500 yards)
-            if (distanceYards.isNaN() || distanceYards.isInfinite()) {
-                analyticsTracker.logGpsError("nan_distance")
-                toast("GPS reading error. Distance could not be calculated.")
-                distanceYards = 0.0
-                distanceMeters = 0.0
-            } else if (distanceYards > 500) {
-                toast("Distance exceeded 500 yards. Capped for accuracy.")
-                distanceYards = 500.0
-                distanceMeters = 500.0 / 1.09361
-            }
+            val rawMeters = haversineMeters(startCoord, endCoord)
+            val (distanceMeters, distanceYards) = clampDistance(rawMeters, metersToYards(rawMeters))
 
             // Use real weather or fallback — 21.1°C (70°F) baseline so temperature effect is zero
             val weather = weatherDeferred.await() ?: WeatherData(
@@ -630,58 +652,78 @@ class ShotTrackerViewModel(application: Application) : AndroidViewModel(applicat
                 shotBearingDegrees = shotBearing
             )
 
-            // Log analytics event first (no PII/location data)
-            analyticsTracker.logShot(result)
-            analyticsTracker.setUserProperties(_uiState.value.settings, _uiState.value.shotHistory.size + 1)
-
-            // Update UI immediately — don't block on network
-            var updatedHistory: List<ShotResult> = emptyList()
+            // Update result UI immediately — don't block on network
             _uiState.update {
-                val history = it.shotHistory + result
-                updatedHistory = history
                 it.copy(
                     phase = ShotPhase.RESULT,
                     shotResult = result,
-                    shotHistory = history,
                     gpsAccuracyMeters = combinedAccuracy
                 )
             }
-            // Persist to SharedPrefs as local backup
-            persistShots(updatedHistory)
+            // Append to history, persist, sync, and check achievements (shared with Range Mode)
+            commitShot(result, capturedUid)
             toast("Shot saved" + if (_uiState.value.isSignedIn) " to cloud" else " locally")
-            // Save to Firestore in background (only when signed in to avoid duplicate local save)
-            if (capturedUid != null) {
-                firestoreSync { repository.saveShot(result, forUid = capturedUid) }
-                viewModelScope.launch { repository.incrementGlobalShotCount() }
-            }
+        }
+    }
 
-            // Check achievements
-            val currentState = _uiState.value
-            val newAchievements = checkAchievements(
-                allShots = currentState.shotHistory,
-                newShot = result,
-                alreadyUnlocked = currentState.unlockedAchievements.keys,
-                enabledClubs = currentState.settings.enabledClubs
-            )
-            if (newAchievements.isNotEmpty()) {
-                val now = System.currentTimeMillis()
-                var mergedMap: Map<String, Long> = emptyMap()
-                _uiState.update { state ->
-                    val merged = state.unlockedAchievements.toMutableMap()
-                    newAchievements.forEach { a -> merged[a.storageKey] = now }
-                    mergedMap = merged
-                    state.copy(
-                        unlockedAchievements = merged,
-                        newlyUnlockedAchievements = newAchievements
-                    )
-                }
-                achievementRepository.saveUnlocked(mergedMap)
-                newAchievements.forEach { achievement ->
-                    analyticsTracker.logAchievement(achievement.category.name, achievement.tier.name)
-                    if (capturedUid != null) {
-                        firestoreSync {
-                            achievementRepository.saveToFirestore(achievement.storageKey, now, capturedUid)
-                        }
+    /**
+     * Shared persistence path for a completed [ShotResult], used by both the single-shot
+     * flow ([markEnd]) and Range Mode ([rangeTrackBall]). Logs analytics, appends the shot to
+     * history, persists locally, syncs to Firestore when signed in, and checks achievements.
+     *
+     * Callers update their own phase/UI fields before invoking this.
+     */
+    private fun commitShot(result: ShotResult, capturedUid: String?) {
+        // Log analytics event first (no PII/location data)
+        analyticsTracker.logShot(result)
+        analyticsTracker.setUserProperties(_uiState.value.settings, _uiState.value.shotHistory.size + 1)
+
+        var updatedHistory: List<ShotResult> = emptyList()
+        _uiState.update {
+            val history = it.shotHistory + result
+            updatedHistory = history
+            it.copy(shotHistory = history)
+        }
+        // Persist to SharedPrefs as local backup
+        persistShots(updatedHistory)
+        // Save to Firestore in background (only when signed in to avoid duplicate local save)
+        if (capturedUid != null) {
+            firestoreSync { repository.saveShot(result, forUid = capturedUid) }
+            viewModelScope.launch { repository.incrementGlobalShotCount() }
+        }
+        processNewAchievements(result, capturedUid)
+    }
+
+    /**
+     * Checks for newly unlocked achievements triggered by [result] and persists/syncs them.
+     * Shared by [commitShot] and [changeResultClub].
+     */
+    private fun processNewAchievements(result: ShotResult, capturedUid: String?) {
+        val currentState = _uiState.value
+        val newAchievements = checkAchievements(
+            allShots = currentState.shotHistory,
+            newShot = result,
+            alreadyUnlocked = currentState.unlockedAchievements.keys,
+            enabledClubs = currentState.settings.enabledClubs
+        )
+        if (newAchievements.isNotEmpty()) {
+            val now = System.currentTimeMillis()
+            var mergedMap: Map<String, Long> = emptyMap()
+            _uiState.update { state ->
+                val merged = state.unlockedAchievements.toMutableMap()
+                newAchievements.forEach { a -> merged[a.storageKey] = now }
+                mergedMap = merged
+                state.copy(
+                    unlockedAchievements = merged,
+                    newlyUnlockedAchievements = newAchievements
+                )
+            }
+            achievementRepository.saveUnlocked(mergedMap)
+            newAchievements.forEach { achievement ->
+                analyticsTracker.logAchievement(achievement.category.name, achievement.tier.name)
+                if (capturedUid != null) {
+                    firestoreSync {
+                        achievementRepository.saveToFirestore(achievement.storageKey, now, capturedUid)
                     }
                 }
             }
@@ -712,35 +754,7 @@ class ShotTrackerViewModel(application: Application) : AndroidViewModel(applicat
         }
         // Re-check achievements with the updated club
         updatedResult?.let { shot ->
-            val currentState = _uiState.value
-            val newAchievements = checkAchievements(
-                allShots = currentState.shotHistory,
-                newShot = shot,
-                alreadyUnlocked = currentState.unlockedAchievements.keys,
-                enabledClubs = currentState.settings.enabledClubs
-            )
-            if (newAchievements.isNotEmpty()) {
-                val now = System.currentTimeMillis()
-                var mergedMap: Map<String, Long> = emptyMap()
-                _uiState.update { state ->
-                    val merged = state.unlockedAchievements.toMutableMap()
-                    newAchievements.forEach { a -> merged[a.storageKey] = now }
-                    mergedMap = merged
-                    state.copy(
-                        unlockedAchievements = merged,
-                        newlyUnlockedAchievements = newAchievements
-                    )
-                }
-                achievementRepository.saveUnlocked(mergedMap)
-                newAchievements.forEach { achievement ->
-                    analyticsTracker.logAchievement(achievement.category.name, achievement.tier.name)
-                    if (capturedUid != null) {
-                        firestoreSync {
-                            achievementRepository.saveToFirestore(achievement.storageKey, now, capturedUid)
-                        }
-                    }
-                }
-            }
+            processNewAchievements(shot, capturedUid)
         }
     }
 
@@ -770,11 +784,274 @@ class ShotTrackerViewModel(application: Application) : AndroidViewModel(applicat
 
     fun reset() = nextShot()
 
+    /**
+     * Clamps implausible GPS distances. NaN/infinite collapse to 0; anything over 500 yards is
+     * capped. Emits a toast (and analytics on NaN) so the user understands the adjustment.
+     * Shared by [markEnd] and [rangeTrackBall]. Returns (meters, yards).
+     */
+    private fun clampDistance(distanceMeters: Double, distanceYards: Double): Pair<Double, Double> =
+        when {
+            distanceYards.isNaN() || distanceYards.isInfinite() -> {
+                analyticsTracker.logGpsError("nan_distance")
+                toast("GPS reading error. Distance could not be calculated.")
+                0.0 to 0.0
+            }
+            distanceYards > 500 -> {
+                toast("Distance exceeded 500 yards. Capped for accuracy.")
+                (500.0 / 1.09361) to 500.0
+            }
+            else -> distanceMeters to distanceYards
+        }
+
+    // ── Range Mode ("one smack, many tracks") ───────────────────────────────────
+    //
+    // A self-contained second state machine that reuses the GPS calibration, foreground
+    // service, and shot-persistence helpers above. One origin is calibrated, then any number
+    // of balls are measured from it. Each ball is committed as a normal ShotResult (shared club,
+    // distinct timestamps) so it flows into Stats/History and groups into one Session.
+
+    private fun startRangeTimeout() {
+        rangeTimeoutJob?.cancel()
+        rangeTimeoutJob = viewModelScope.launch {
+            delay(SHOT_TIMEOUT_MS)
+            toast("Range session timed out after 15 minutes")
+            rangeEndSession()
+        }
+    }
+
+    private fun cancelRangeTimeout() {
+        rangeTimeoutJob?.cancel()
+        rangeTimeoutJob = null
+    }
+
+    fun rangeSelectClub(club: Club) {
+        if (_uiState.value.rangePhase != RangePhase.IDLE) return
+        _uiState.update { it.copy(rangeClub = club) }
+    }
+
+    /**
+     * Starts a range session: calibrates a single origin (reusing the adaptive start
+     * calibration), fetches weather once for the whole session, then enters [RangePhase.TRACKING]
+     * and begins polling the live distance from the origin.
+     */
+    fun rangeStartSession() {
+        if (_uiState.value.rangePhase != RangePhase.IDLE) return
+        rangeWeather = null
+        val sessionToken = ++rangeSessionToken
+        _uiState.update {
+            it.copy(
+                rangePhase = RangePhase.CALIBRATING_ORIGIN,
+                rangeOrigin = null,
+                rangeBalls = emptyList(),
+                rangeLiveDistanceYards = 0,
+                rangeLiveDistanceMeters = 0,
+                calibrationAccuracyMeters = null,
+                calibrationProgress = 0f
+            )
+        }
+
+        startLocationUpdates()
+        if (_uiState.value.locationPermissionGranted) {
+            startTrackingService()
+        }
+        startRangeTimeout()
+
+        viewModelScope.launch {
+            // Wait for a fresh GPS fix, then warm up weather in parallel with calibration so the
+            // network call never blocks the origin → tracking transition.
+            waitForFreshGps()
+            val warmSnap = gpsState
+            val weatherDeferred = async {
+                if (warmSnap.lat != 0.0 || warmSnap.lon != 0.0) {
+                    WeatherService.fetchWeather(warmSnap.lat, warmSnap.lon)
+                } else null
+            }
+
+            val samples = collectGpsSamplesAdaptive()
+            val calibrated = calibrateWeighted(samples)
+
+            val snap = gpsState
+            val originCoord = calibrated?.coordinate
+                ?: if (snap.lat != 0.0 || snap.lon != 0.0) {
+                    GpsCoordinate(snap.lat, snap.lon)
+                } else {
+                    // No valid GPS position — abort and return to idle
+                    weatherDeferred.cancel()
+                    analyticsTracker.logGpsError("no_fix_on_range_origin")
+                    toast("Could not get GPS position. Try again in an open area.")
+                    _uiState.update { it.copy(rangePhase = RangePhase.IDLE) }
+                    stopLocationUpdates()
+                    stopTrackingService()
+                    cancelRangeTimeout()
+                    return@launch
+                }
+
+            // Re-check phase — user may have cancelled during calibration
+            if (_uiState.value.rangePhase != RangePhase.CALIBRATING_ORIGIN) {
+                weatherDeferred.cancel()
+                return@launch
+            }
+
+            // Enter TRACKING immediately — don't block on the weather network call
+            _uiState.update {
+                it.copy(
+                    rangePhase = RangePhase.TRACKING,
+                    rangeOrigin = originCoord,
+                    rangeLiveDistanceYards = 0,
+                    rangeLiveDistanceMeters = 0
+                )
+            }
+
+            // Store the session weather once it resolves (reused for every ball). Guard on the
+            // session token so a slow fetch from a prior session can't overwrite a newer one.
+            launch {
+                val weather = weatherDeferred.await()
+                if (sessionToken == rangeSessionToken) rangeWeather = weather
+            }
+
+            pollRangeLiveDistance(originCoord)
+        }
+    }
+
+    private suspend fun pollRangeLiveDistance(origin: GpsCoordinate) {
+        while (_uiState.value.rangePhase == RangePhase.TRACKING) {
+            delay(500)
+
+            // Freeze the live number while a ball is being captured (matches the single-shot flow,
+            // which stops polling by switching phase during end-calibration).
+            if (_uiState.value.rangeCapturing) continue
+
+            val snap = gpsState
+            if (snap.lat == 0.0 && snap.lon == 0.0) continue
+
+            val currentPos = GpsCoordinate(snap.lat, snap.lon)
+            val distanceMeters = haversineMeters(origin, currentPos)
+            val distanceYards = metersToYards(distanceMeters)
+
+            if (!distanceYards.isNaN() && !distanceMeters.isNaN()) {
+                _uiState.update {
+                    it.copy(
+                        rangeLiveDistanceYards = distanceYards.roundToInt(),
+                        rangeLiveDistanceMeters = distanceMeters.roundToInt()
+                    )
+                }
+            }
+        }
+    }
+
+    /**
+     * Records the current position as a tracked ball: runs a brief end-calibration, computes the
+     * distance from the fixed origin, and commits it as a [ShotResult] (shared with [markEnd]).
+     * Stays in [RangePhase.TRACKING] so the golfer can keep tracking the next ball.
+     */
+    fun rangeTrackBall() {
+        val state = _uiState.value
+        if (state.rangePhase != RangePhase.TRACKING || state.rangeCapturing) return
+        val origin = state.rangeOrigin ?: return
+        val club = state.rangeClub
+        val capturedUid = repository.snapshotUid()
+
+        // Keep the session alive — user is actively tracking
+        startRangeTimeout()
+        _uiState.update { it.copy(rangeCapturing = true) }
+
+        viewModelScope.launch {
+            val samples = collectGpsSamples(END_CALIBRATION_DURATION_MS)
+
+            // Aborted mid-calibration (session ended) — don't create a ghost ball
+            if (_uiState.value.rangePhase != RangePhase.TRACKING) {
+                _uiState.update { it.copy(rangeCapturing = false) }
+                return@launch
+            }
+
+            val calibrated = calibrateWeighted(samples)
+            val endSnap = gpsState
+            val ballCoord = calibrated?.coordinate
+                ?: if (endSnap.lat != 0.0 || endSnap.lon != 0.0) {
+                    GpsCoordinate(endSnap.lat, endSnap.lon)
+                } else {
+                    analyticsTracker.logGpsError("signal_lost_on_range_track")
+                    toast("GPS signal lost. Distance may be inaccurate.")
+                    origin
+                }
+
+            val rawMeters = haversineMeters(origin, ballCoord)
+            val (distanceMeters, distanceYards) = clampDistance(rawMeters, metersToYards(rawMeters))
+
+            // Reuse the session weather (fetched once at origin); fall back to a neutral baseline
+            val weather = rangeWeather ?: WeatherData(
+                temperatureCelsius = 21.1,
+                weatherCode = -1,
+                windSpeedKmh = 0.0,
+                windDirectionDegrees = 0
+            )
+
+            val result = ShotResult(
+                club = club,
+                distanceYards = distanceYards.roundToInt(),
+                distanceMeters = distanceMeters.roundToInt(),
+                weatherDescription = wmoCodeToLabel(weather.weatherCode),
+                temperatureF = celsiusToFahrenheit(weather.temperatureCelsius).roundToInt(),
+                temperatureC = weather.temperatureCelsius.roundToInt(),
+                windSpeedKmh = weather.windSpeedKmh,
+                windDirectionCompass = degreesToCompass(weather.windDirectionDegrees),
+                windDirectionDegrees = weather.windDirectionDegrees,
+                shotBearingDegrees = bearingDegrees(origin, ballCoord)
+            )
+
+            // Add to this session's ball list (newest last) and clear the capturing flag
+            _uiState.update { it.copy(rangeBalls = it.rangeBalls + result, rangeCapturing = false) }
+            // Append to history, persist, sync, check achievements (shared with single-shot flow)
+            commitShot(result, capturedUid)
+        }
+    }
+
+    /** Ends the active range session and shows the summary (or returns to idle if no balls). */
+    fun rangeEndSession() {
+        val state = _uiState.value
+        if (state.rangePhase != RangePhase.TRACKING) return
+        stopLocationUpdates()
+        stopTrackingService()
+        cancelRangeTimeout()
+        if (state.rangeBalls.isEmpty()) {
+            rangeReset()
+        } else {
+            // Clear any range-earned achievement banner so it can't leak onto a later single shot's
+            // result (RangeScreen doesn't render the banner; the trophy badge is the in-session cue).
+            _uiState.update {
+                it.copy(rangePhase = RangePhase.SUMMARY, newlyUnlockedAchievements = emptyList())
+            }
+        }
+    }
+
+    /** Resets Range Mode back to idle, clearing all session state. */
+    fun rangeReset() {
+        stopLocationUpdates()
+        stopTrackingService()
+        cancelRangeTimeout()
+        clearGpsState()
+        rangeWeather = null
+        _uiState.update {
+            it.copy(
+                rangePhase = RangePhase.IDLE,
+                rangeOrigin = null,
+                rangeLiveDistanceYards = 0,
+                rangeLiveDistanceMeters = 0,
+                rangeBalls = emptyList(),
+                rangeCapturing = false,
+                newlyUnlockedAchievements = emptyList(),
+                calibrationAccuracyMeters = null,
+                calibrationProgress = 0f
+            )
+        }
+    }
+
     override fun onCleared() {
         super.onCleared()
         stopLocationUpdates()
         stopTrackingService()
         cancelShotTimeout()
+        cancelRangeTimeout()
         authManager?.cleanup()
     }
 

--- a/app/src/main/java/com/smacktrack/golf/ui/screen/RangeScreen.kt
+++ b/app/src/main/java/com/smacktrack/golf/ui/screen/RangeScreen.kt
@@ -1,0 +1,555 @@
+package com.smacktrack.golf.ui.screen
+
+/**
+ * Range Mode screen — the "one smack, many tracks" workflow.
+ *
+ * Mirrors the visual language of [ShotTrackerScreen] and reuses its calibration, button, and chip
+ * composables. Four phases ([RangePhase]):
+ * 1. **Idle** — pick the club you're dialing in, tap SMACK to lock your hitting spot
+ * 2. **Calibrating origin** — GPS lock on the single origin (reuses [CalibratingContent])
+ * 3. **Tracking** — live distance from origin, TRACK each ball, running dispersion stats + ball list
+ * 4. **Summary** — session recap (count / avg / longest / shortest / spread)
+ *
+ * Each tracked ball is a normal [ShotResult] saved to history, so Stats and History pick them up
+ * automatically and group them into one session.
+ */
+
+import android.app.Activity
+import android.view.WindowManager
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.smacktrack.golf.domain.Club
+import com.smacktrack.golf.ui.DistanceUnit
+import com.smacktrack.golf.ui.RangePhase
+import com.smacktrack.golf.ui.ShotResult
+import com.smacktrack.golf.ui.ShotTrackerUiState
+import com.smacktrack.golf.ui.primaryDistance
+import com.smacktrack.golf.ui.theme.ChipUnselectedBg
+import com.smacktrack.golf.ui.theme.DarkGreen
+import com.smacktrack.golf.ui.theme.Red40
+import com.smacktrack.golf.ui.theme.RobotoFamily
+import com.smacktrack.golf.ui.theme.TextPrimary
+import com.smacktrack.golf.ui.theme.TextSecondary
+import com.smacktrack.golf.ui.theme.TextTertiary
+import androidx.compose.ui.text.TextStyle
+import kotlin.math.roundToInt
+
+@Composable
+fun RangeScreen(
+    uiState: ShotTrackerUiState,
+    onSelectClub: (Club) -> Unit,
+    onStartSession: () -> Unit,
+    onTrackBall: () -> Unit,
+    onEndSession: () -> Unit,
+    onReset: () -> Unit,
+    onDone: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val settings = uiState.settings
+
+    // Keep the screen awake while calibrating or tracking
+    val keepScreenOn = uiState.rangePhase == RangePhase.CALIBRATING_ORIGIN ||
+        uiState.rangePhase == RangePhase.TRACKING
+    val activity = (LocalContext.current as? Activity)
+    DisposableEffect(keepScreenOn) {
+        if (keepScreenOn) {
+            activity?.window?.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        }
+        onDispose {
+            activity?.window?.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        }
+    }
+
+    AnimatedContent(
+        targetState = uiState.rangePhase,
+        transitionSpec = {
+            val isForward = targetState.ordinal > initialState.ordinal
+            if (isForward) {
+                (fadeIn(tween(400)) + scaleIn(initialScale = 0.95f, animationSpec = tween(400)) +
+                    slideInVertically(tween(400)) { it / 12 }) togetherWith
+                    (fadeOut(tween(250)) + slideOutVertically(tween(250)) { -it / 10 })
+            } else {
+                (fadeIn(tween(300)) + slideInVertically(tween(300)) { -it / 10 }) togetherWith
+                    (fadeOut(tween(200)) + slideOutVertically(tween(200)) { it / 8 })
+            }
+        },
+        modifier = modifier.fillMaxSize(),
+        label = "rangePhase"
+    ) { phase ->
+        when (phase) {
+            RangePhase.IDLE -> RangeIdleContent(
+                selectedClub = uiState.rangeClub,
+                enabledClubs = settings.enabledClubs,
+                onSelectClub = onSelectClub,
+                onStart = onStartSession
+            )
+            RangePhase.CALIBRATING_ORIGIN -> CalibratingContent(
+                // "start" in the label routes to the real-accuracy adaptive UI + "Hold still at your ball"
+                label = "Marking start position",
+                realAccuracyMeters = uiState.calibrationAccuracyMeters,
+                realProgress = uiState.calibrationProgress,
+                onCancel = onReset
+            )
+            RangePhase.TRACKING -> RangeTrackingContent(
+                uiState = uiState,
+                onTrackBall = onTrackBall,
+                onEndSession = onEndSession
+            )
+            RangePhase.SUMMARY -> RangeSummaryContent(
+                club = uiState.rangeClub,
+                balls = uiState.rangeBalls,
+                distanceUnit = settings.distanceUnit,
+                onDone = onDone
+            )
+        }
+    }
+}
+
+// ── Idle: pick a club, smack a bucket ───────────────────────────────────────
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun RangeIdleContent(
+    selectedClub: Club,
+    enabledClubs: Set<Club>,
+    onSelectClub: (Club) -> Unit,
+    onStart: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Spacer(Modifier.height(24.dp))
+
+        Text(
+            text = "RANGE MODE",
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.ExtraBold,
+            color = TextPrimary,
+            letterSpacing = 2.sp
+        )
+        Spacer(Modifier.height(4.dp))
+        Text(
+            text = "One smack, many tracks — dial in a single club.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = TextSecondary
+        )
+
+        Spacer(Modifier.height(24.dp))
+
+        Text(
+            text = "CLUB",
+            style = MaterialTheme.typography.labelMedium,
+            color = TextSecondary,
+            fontWeight = FontWeight.SemiBold,
+            letterSpacing = 1.5.sp
+        )
+        Spacer(Modifier.height(10.dp))
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Club.entries
+                .filter { it in enabledClubs }
+                .sortedBy { it.sortOrder }
+                .forEach { c ->
+                    ClubChip(
+                        club = c,
+                        selected = c == selectedClub,
+                        onClick = { onSelectClub(c) }
+                    )
+                }
+        }
+
+        Spacer(Modifier.height(32.dp))
+
+        EpicButton(text = "SMACK", pulsate = true) { onStart() }
+
+        Spacer(Modifier.height(16.dp))
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(8.dp))
+                .background(ChipUnselectedBg)
+                .padding(16.dp)
+        ) {
+            Text(
+                text = "Hit a bucket of balls, then walk out and TRACK each one. " +
+                    "Every ball is measured from where you stood and saved to your stats.",
+                style = MaterialTheme.typography.bodySmall,
+                color = TextSecondary
+            )
+        }
+
+        Spacer(Modifier.height(24.dp))
+    }
+}
+
+// ── Tracking: live distance + TRACK + running stats + ball list ─────────────
+
+@Composable
+private fun RangeTrackingContent(
+    uiState: ShotTrackerUiState,
+    onTrackBall: () -> Unit,
+    onEndSession: () -> Unit
+) {
+    var showEndConfirm by remember { mutableStateOf(false) }
+    val settings = uiState.settings
+    val useYards = settings.distanceUnit == DistanceUnit.YARDS
+    val unitShort = if (useYards) "yd" else "m"
+    val liveDistance = if (useYards) uiState.rangeLiveDistanceYards else uiState.rangeLiveDistanceMeters
+    val secondary = if (useYards) "${uiState.rangeLiveDistanceMeters}m" else "${uiState.rangeLiveDistanceYards}yd"
+
+    val distances = uiState.rangeBalls.map { it.primaryDistance(settings.distanceUnit) }
+    val stats = RangeStats.from(distances)
+
+    if (showEndConfirm) {
+        AlertDialog(
+            onDismissRequest = { showEndConfirm = false },
+            title = { Text("End session?") },
+            text = { Text("You've tracked ${distances.size} ${if (distances.size == 1) "ball" else "balls"}. They're already saved to your history.") },
+            confirmButton = {
+                TextButton(onClick = { showEndConfirm = false; onEndSession() }) {
+                    Text("End", color = DarkGreen)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showEndConfirm = false }) { Text("Keep going") }
+            }
+        )
+    }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        // Pinned at the top so it's always visible — red and compact (smaller than TRACK).
+        // Nothing tracked yet → just exit; otherwise confirm so a session isn't lost by mistake.
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 24.dp, end = 24.dp, top = 12.dp, bottom = 4.dp),
+            horizontalArrangement = Arrangement.Center
+        ) {
+            EndSessionButton(
+                onClick = { if (distances.isEmpty()) onEndSession() else showEndConfirm = true }
+            )
+        }
+
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Spacer(Modifier.height(4.dp))
+
+            // Locked club badge
+            ClubBadge(uiState.rangeClub)
+            Spacer(Modifier.height(12.dp))
+
+            // Live distance from origin
+            Text(
+                text = "$liveDistance",
+                style = DistanceLive,
+                color = TextPrimary
+            )
+            Text(
+                text = if (useYards) "YARDS" else "METERS",
+                style = MaterialTheme.typography.labelMedium,
+                color = TextSecondary,
+                fontWeight = FontWeight.SemiBold,
+                letterSpacing = 4.sp
+            )
+            Spacer(Modifier.height(2.dp))
+            Text(
+                text = secondary,
+                style = MaterialTheme.typography.bodyMedium,
+                color = TextSecondary
+            )
+
+            Spacer(Modifier.height(16.dp))
+
+            EpicButton(
+                text = if (uiState.rangeCapturing) "LOCKING…" else "TRACK",
+                enabled = !uiState.rangeCapturing
+            ) { onTrackBall() }
+
+            Spacer(Modifier.height(16.dp))
+
+            // Running dispersion stats
+            if (stats != null) {
+                RangeStatsCard(stats = stats, unitLabel = unitShort)
+                Spacer(Modifier.height(12.dp))
+            }
+
+            // Tracked balls — newest first, numbered by hit order
+            if (uiState.rangeBalls.isNotEmpty()) {
+                Text(
+                    text = "THIS SESSION",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = TextSecondary,
+                    fontWeight = FontWeight.SemiBold,
+                    letterSpacing = 1.5.sp,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Spacer(Modifier.height(8.dp))
+                uiState.rangeBalls
+                    .mapIndexed { index, ball -> (index + 1) to ball }
+                    .reversed()
+                    .forEach { (number, ball) ->
+                        RangeBallRow(
+                            number = number,
+                            distance = ball.primaryDistance(settings.distanceUnit),
+                            unitLabel = unitShort
+                        )
+                        Spacer(Modifier.height(6.dp))
+                    }
+            }
+
+            Spacer(Modifier.height(24.dp))
+        }
+    }
+}
+
+@Composable
+private fun EndSessionButton(onClick: () -> Unit) {
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(12.dp))
+            .background(Red40)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 32.dp, vertical = 12.dp)
+    ) {
+        Text(
+            text = "End Session",
+            style = MaterialTheme.typography.labelLarge,
+            color = Color.White,
+            fontWeight = FontWeight.Bold
+        )
+    }
+}
+
+// ── Summary ─────────────────────────────────────────────────────────────────
+
+@Composable
+private fun RangeSummaryContent(
+    club: Club,
+    balls: List<ShotResult>,
+    distanceUnit: DistanceUnit,
+    onDone: () -> Unit
+) {
+    val distances = balls.map { it.primaryDistance(distanceUnit) }
+    val stats = RangeStats.from(distances)
+    val unitShort = if (distanceUnit == DistanceUnit.YARDS) "yd" else "m"
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Spacer(Modifier.height(24.dp))
+
+        Text(
+            text = "SESSION COMPLETE",
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.ExtraBold,
+            color = TextPrimary,
+            letterSpacing = 1.5.sp
+        )
+        Spacer(Modifier.height(12.dp))
+        ClubBadge(club)
+        Spacer(Modifier.height(24.dp))
+
+        if (stats != null) {
+            RangeStatsCard(stats = stats, unitLabel = unitShort)
+            Spacer(Modifier.height(12.dp))
+            // Spread (consistency)
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(ChipUnselectedBg)
+                    .padding(16.dp)
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = "Spread (longest − shortest)",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = TextSecondary
+                    )
+                    Text(
+                        text = "${stats.spread} $unitShort",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = TextPrimary
+                    )
+                }
+            }
+        }
+
+        Spacer(Modifier.height(24.dp))
+
+        EpicButton(text = "DONE") { onDone() }
+
+        Spacer(Modifier.height(12.dp))
+        Text(
+            text = "Saved to your History & Stats.",
+            style = MaterialTheme.typography.bodySmall,
+            color = TextTertiary
+        )
+        Spacer(Modifier.height(24.dp))
+    }
+}
+
+// ── Shared pieces ────────────────────────────────────────────────────────────
+
+private data class RangeStats(
+    val count: Int,
+    val avg: Int,
+    val longest: Int,
+    val shortest: Int
+) {
+    val spread: Int get() = longest - shortest
+
+    companion object {
+        fun from(distances: List<Int>): RangeStats? {
+            if (distances.isEmpty()) return null
+            return RangeStats(
+                count = distances.size,
+                avg = distances.average().roundToInt(),
+                longest = distances.max(),
+                shortest = distances.min()
+            )
+        }
+    }
+}
+
+@Composable
+private fun RangeStatsCard(stats: RangeStats, unitLabel: String) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .background(ChipUnselectedBg)
+            .padding(16.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceEvenly
+        ) {
+            RangeStatColumn("${stats.count}", "Balls")
+            RangeStatColumn("${stats.avg}", "Avg $unitLabel")
+            RangeStatColumn("${stats.longest}", "Long", valueColor = DarkGreen)
+            RangeStatColumn("${stats.shortest}", "Short")
+        }
+    }
+}
+
+@Composable
+private fun RangeStatColumn(value: String, label: String, valueColor: Color = TextPrimary) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(
+            text = value,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+            color = valueColor
+        )
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = TextTertiary
+        )
+    }
+}
+
+@Composable
+private fun RangeBallRow(number: Int, distance: Int, unitLabel: String) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .background(ChipUnselectedBg)
+            .padding(horizontal = 16.dp, vertical = 10.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "#$number",
+                style = MaterialTheme.typography.labelLarge,
+                color = TextTertiary,
+                fontWeight = FontWeight.SemiBold
+            )
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = "$distance",
+                    style = TextStyle(
+                        fontFamily = RobotoFamily,
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 22.sp,
+                        fontFeatureSettings = "tnum"
+                    ),
+                    color = TextPrimary
+                )
+                Text(
+                    text = " $unitLabel",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = TextSecondary
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/smacktrack/golf/ui/screen/ShotTrackerScreen.kt
+++ b/app/src/main/java/com/smacktrack/golf/ui/screen/ShotTrackerScreen.kt
@@ -121,7 +121,7 @@ import com.smacktrack.golf.ui.theme.clubChipColor
 import com.smacktrack.golf.ui.theme.windCategoryColor
 
 // Distance number styles — Roboto with tabular figures so digits don't jump
-private val DistanceLive = TextStyle(
+internal val DistanceLive = TextStyle(
     fontFamily = RobotoFamily,
     fontWeight = FontWeight.Bold,
     fontSize = 96.sp,
@@ -407,7 +407,7 @@ private fun RecentShotRow(shot: ShotResult, settings: AppSettings, onDelete: (()
 }
 
 @Composable
-private fun ClubChip(
+internal fun ClubChip(
     club: Club,
     selected: Boolean,
     onClick: () -> Unit
@@ -436,7 +436,7 @@ private fun ClubChip(
 // ── Epic Button ─────────────────────────────────────────────────────────────
 
 @Composable
-private fun EpicButton(
+internal fun EpicButton(
     text: String,
     enabled: Boolean = true,
     pulsate: Boolean = false,
@@ -519,7 +519,7 @@ private data class SignalParticle(
 )
 
 @Composable
-private fun CalibratingContent(
+internal fun CalibratingContent(
     label: String,
     realAccuracyMeters: Double?,
     realProgress: Float?,

--- a/app/src/test/java/com/smacktrack/golf/ui/screen/RangeSessionTest.kt
+++ b/app/src/test/java/com/smacktrack/golf/ui/screen/RangeSessionTest.kt
@@ -1,0 +1,88 @@
+package com.smacktrack.golf.ui.screen
+
+import com.smacktrack.golf.domain.Club
+import com.smacktrack.golf.ui.DistanceUnit
+import com.smacktrack.golf.ui.ShotResult
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+/**
+ * Validates the Range Mode ("one smack, many tracks") storage design: a burst of same-club balls
+ * tracked seconds apart must group into a single History [Session] and produce correct dispersion
+ * stats, since each ball is persisted as a normal [ShotResult].
+ */
+@DisplayName("Range Mode session grouping")
+class RangeSessionTest {
+
+    /** A range ball: same club, distinct timestamp seconds after the previous one. */
+    private fun ball(timestampMs: Long, yards: Int, club: Club = Club.SEVEN_IRON) = ShotResult(
+        club = club,
+        distanceYards = yards,
+        distanceMeters = (yards * 0.9144).toInt(),
+        weatherDescription = "Clear",
+        temperatureF = 72,
+        temperatureC = 22,
+        windSpeedKmh = 8.0,
+        windDirectionCompass = "N",
+        timestampMs = timestampMs
+    )
+
+    /** Simulates a range session: N balls of one club, each tracked ~20s apart. */
+    private fun rangeSession(start: Long, distances: List<Int>, club: Club = Club.SEVEN_IRON) =
+        distances.mapIndexed { i, yards -> ball(start + i * 20_000L, yards, club) }
+
+    @Test
+    @DisplayName("a burst of balls seconds apart groups into one session")
+    fun burstGroupsIntoOneSession() {
+        val balls = rangeSession(1_000_000L, listOf(150, 158, 145, 162, 151, 149, 155))
+        val sessions = groupIntoSessions(balls)
+        assertEquals(1, sessions.size)
+        assertEquals(7, sessions[0].shots.size)
+    }
+
+    @Test
+    @DisplayName("all balls in a session share the tracked club")
+    fun allBallsShareClub() {
+        val balls = rangeSession(1_000_000L, listOf(240, 251, 233, 245), club = Club.DRIVER)
+        val sessions = groupIntoSessions(balls)
+        assertEquals(1, sessions.size)
+        assertTrue(sessions[0].shots.all { it.club == Club.DRIVER })
+    }
+
+    @Test
+    @DisplayName("range session does not absorb an unrelated earlier shot")
+    fun separateFromEarlierSession() {
+        val earlier = ball(1_000_000L, 100, Club.PITCHING_WEDGE)
+        // Range session starts an hour later
+        val balls = rangeSession(1_000_000L + 60 * 60 * 1000L, listOf(150, 158, 145))
+        val sessions = groupIntoSessions(listOf(earlier) + balls)
+        assertEquals(2, sessions.size)
+        assertEquals(1, sessions[0].shots.size)
+        assertEquals(3, sessions[1].shots.size)
+    }
+
+    @Test
+    @DisplayName("session summary reports correct count, average and best for a range bucket")
+    fun summaryStatsForBucket() {
+        val balls = rangeSession(1_000_000L, listOf(150, 160, 140, 170, 130))
+        val sessions = groupIntoSessions(balls)
+        val summary = computeSessionSummary(sessions[0].shots, DistanceUnit.YARDS)
+        assertNotNull(summary)
+        assertEquals(5, summary!!.totalShots)
+        assertEquals(150, summary.avgDistance)   // (150+160+140+170+130)/5
+        assertEquals(170, summary.bestDistance)
+        assertEquals(1, summary.clubsUsedCount)   // single club for the whole bucket
+    }
+
+    @Test
+    @DisplayName("dispersion (longest minus shortest) matches the tracked distances")
+    fun dispersionSpread() {
+        val balls = rangeSession(1_000_000L, listOf(150, 162, 145, 158))
+        val yards = balls.map { it.distanceYards }
+        val spread = yards.max() - yards.min()
+        assertEquals(17, spread) // 162 - 145
+    }
+}


### PR DESCRIPTION
## Summary

Adds **Range Mode**, a new bottom-nav tab for club-dispersion practice: calibrate one GPS origin, then tap **TRACK** for each ball you walk to — every ball measured from that single origin. Built for dialing in a specific club over many balls. Foundation for the future paid "Pro" tier (no paywall yet).

Each tracked ball is saved as a normal `ShotResult`, so it flows into existing **Stats/History** and groups into one session via the existing 30-min session grouping — no new storage type.

## What's included

### Feature
- `RangePhase` state machine (IDLE → CALIBRATING_ORIGIN → TRACKING → SUMMARY) inside `ShotTrackerViewModel`, reusing the GPS calibration, foreground-service, and persistence helpers
- `RangeScreen.kt`: idle / calibrate / tracking / summary UI, reusing `CalibratingContent` / `EpicButton` / `ClubChip`; red **End Session** pinned at top; live dispersion stats (count / avg / long / short) + per-ball list
- New "Range" bottom-nav tab (Tracker · Range · Stats · History)

### Refactor (no behavior change to single shots)
- Extracted shared `commitShot()` / `processNewAchievements()` / `clampDistance()` from `markEnd()` and `changeResultClub()`; reused by both flows

### Review & hardening (from code-review + regression passes)
- Weather fetched once per session in parallel (non-blocking), guarded by a session token
- Live distance freezes during ball capture
- Bottom nav locks to the active GPS flow; `selectedTab` is `rememberSaveable` and synced to it; lingering SUMMARY reset on tab-leave and on shot start
- Cross-flow guard so a single shot can't start while a range session is using GPS

### Release prep
- Version 1.0.1 → **1.0.6**
- Removed ad-related permissions (AD_ID / ACCESS_ADSERVICES) injected transitively by the Firebase measurement SDK

## Testing
- `RangeSessionTest` validates rapid same-club balls group into one session with correct dispersion
- Full unit suite + lint pass; debug build green
- Verified end-to-end on emulator (API 36): tracking, dispersion summary, History (3 balls → 1 session), Stats by-club

## Notes
- Branch aligned to `master` (merged, clean); backup tag `v1.0.1-pre-range` marks the pre-feature state
- Local dev scratch (screenshots, demo video) gitignored, not committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)